### PR TITLE
[feature] Trigger shortcut from manager

### DIFF
--- a/static/js/index.js
+++ b/static/js/index.js
@@ -21,9 +21,8 @@ var _init = function() {
         break;
       case TRIGGER_SHORTCUT:
         // receive shortcut from manager and trigger it in etherpad
-        var keyEvent = new KeyboardEvent('keydown', e.data.shortcut);
-        utils.getPadInner().get(0).dispatchEvent(keyEvent);
-        break;
+      _triggerShortcut(e.data.shortcut);
+      break;
     }
   });
 
@@ -49,6 +48,11 @@ var _registerShortcuts = function(shortcuts) {
   for (var i = targets.length - 1; i >= 0; i--) {
     Mousetrap(targets[i]).bind(shortcuts, _triggerShortcutPressed);
   }
+}
+
+var _triggerShortcut = function(shortcut){
+  var keyEvent = new KeyboardEvent('keydown', shortcut);
+  utils.getPadInner().get(0).dispatchEvent(keyEvent);
 }
 
 var _triggerReadyEvent = function() {

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -1,9 +1,11 @@
 var $ = require('ep_etherpad-lite/static/js/rjquery').$;
+var utils = require('./utils');
 
 var EDITOR_READY = 'editor_ready';
 var REGISTER_SHORTCUTS = 'register_shortcuts';
 var SHORTCUT_TRIGGERED = 'shortcut_triggered';
 var CLICK_ON_EDITOR = 'click_on_editor';
+var TRIGGER_SHORTCUT = 'trigger_shortcut';
 
 exports.postAceInit = function(hook, context) {
   _init();
@@ -12,8 +14,16 @@ exports.postAceInit = function(hook, context) {
 var _init = function() {
   // listen to outbound calls of this API
   window.addEventListener('message', function(e) {
-    if (e.data.type === REGISTER_SHORTCUTS) {
-      _registerShortcuts(e.data.combos)
+    switch (e.data.type) {
+      case REGISTER_SHORTCUTS:
+        // when the registered shortcut is used, the manager gets notified
+        _registerShortcuts(e.data.combos);
+        break;
+      case TRIGGER_SHORTCUT:
+        // receive shortcut from manager and trigger it in etherpad
+        var keyEvent = new KeyboardEvent('keydown', e.data.shortcut);
+        utils.getPadInner().get(0).dispatchEvent(keyEvent);
+        break;
     }
   });
 

--- a/static/js/utils.js
+++ b/static/js/utils.js
@@ -1,4 +1,3 @@
-var _ = require('ep_etherpad-lite/static/js/underscore');
 var $ = require('ep_etherpad-lite/static/js/rjquery').$;
 
 // Easier access to outer pad

--- a/static/js/utils.js
+++ b/static/js/utils.js
@@ -1,0 +1,16 @@
+var _ = require('ep_etherpad-lite/static/js/underscore');
+var $ = require('ep_etherpad-lite/static/js/rjquery').$;
+
+// Easier access to outer pad
+var padOuter;
+exports.getPadOuter = function() {
+  padOuter = padOuter || $('iframe[name="ace_outer"]').contents();
+  return padOuter;
+}
+
+// Easier access to inner pad
+var padInner;
+exports.getPadInner = function() {
+  padInner = padInner || this.getPadOuter().find('iframe[name="ace_inner"]').contents();
+  return padInner;
+}

--- a/static/tests/frontend/specs/_apiUtils.js
+++ b/static/tests/frontend/specs/_apiUtils.js
@@ -32,6 +32,7 @@ ep_external_shortcuts_test_helper.apiUtils = {
 
   /**** messages coming from outside ****/
   REGISTER_SHORTCUTS: 'register_shortcuts',
+  TRIGGER_SHORTCUT: 'trigger_shortcut',
 
   _simulateEventCall: function(message) {
     ep_script_touches_test_helper.apiUtils._simulateEventCall(message);
@@ -44,4 +45,12 @@ ep_external_shortcuts_test_helper.apiUtils = {
     };
     this._simulateEventCall(message);
   },
+
+  simulateCallToTriggerShortcut: function(shortcut) {
+    var message = {
+      type: this.TRIGGER_SHORTCUT,
+      shortcut: shortcut
+    };
+    this._simulateEventCall(message);
+  }
 }

--- a/static/tests/frontend/specs/_utils.js
+++ b/static/tests/frontend/specs/_utils.js
@@ -1,9 +1,12 @@
 var ep_external_shortcuts_test_helper = ep_external_shortcuts_test_helper || {};
 ep_external_shortcuts_test_helper.utils = {
+
   createPad: function(test, done) {
+    var self = this;
     test.timeout(60000);
     helper.newPad(function() {
       ep_external_shortcuts_test_helper.apiUtils.startListeningToApiEvents();
+      self.startListeningToKeyEvents();
       done();
     });
   },
@@ -30,4 +33,18 @@ ep_external_shortcuts_test_helper.utils = {
     e.metaKey = _.contains(modifierKeys, this.CMD_KEY);
   },
 
+  resetLastKeyEvent: function() {
+    this.lastKeyEvent = null;
+  },
+
+  getLastKeyEvent: function() {
+    return this.lastKeyEvent;
+  },
+
+  startListeningToKeyEvents: function() {
+    var self = this;
+    helper.padInner$.document.addEventListener('keydown', function(evt){
+      self.lastKeyEvent = evt;
+    });
+  }
 }

--- a/static/tests/frontend/specs/triggerShortcut.js
+++ b/static/tests/frontend/specs/triggerShortcut.js
@@ -1,0 +1,28 @@
+describe('ep_external_shortcuts - api - triggers shortcut', function() {
+  var utils = ep_external_shortcuts_test_helper.utils;
+  var apiUtils = ep_external_shortcuts_test_helper.apiUtils;
+
+  before(function (done) {
+    utils.createPad(this, function () {
+      done();
+    });
+    this.timeout(60000);
+  });
+
+  context('when pad receives a shortcut from manager', function () {
+    before(function () {
+      utils.resetLastKeyEvent();
+      const shortcut = { charCode: 90, ctrlKey: true };
+      apiUtils.simulateCallToTriggerShortcut(shortcut);
+    });
+
+    it('triggers shortcut in pad', function (done) {
+      helper.waitFor(function () {
+        var lastKeyEvent = utils.getLastKeyEvent();
+        return lastKeyEvent &&
+               lastKeyEvent.charCode === 90 &&
+               lastKeyEvent.ctrlKey === true;
+      }).done(done);
+    });
+  });
+});


### PR DESCRIPTION
With this commit, we can receive a shortcut used in the manager and
trigger it inside etherpad.

Implements part of [card 2885](https://trello.com/c/cRuLA6bZ/2885-fazer-undo-funcionar-a-partir-do-react).